### PR TITLE
キー操作で描画しているブロックを動かせるようになりました。

### DIFF
--- a/src/main/java/window/GameWindow.java
+++ b/src/main/java/window/GameWindow.java
@@ -25,13 +25,13 @@ public class GameWindow extends JPanel implements Window, Runnable {
         this.setDoubleBuffered(true);
         this.addKeyListener(keyHandler);
         this.setFocusable(true);
+        this.startThread();
     }
 
     @Override
     public void frame() {
 
         gameFrame.createFrame();
-        startThread();
     }
 
     public void startThread() {
@@ -79,19 +79,15 @@ public class GameWindow extends JPanel implements Window, Runnable {
     public void update() {
         if (keyHandler.getUpPressed() == true) {
             playerY -= playerSpeed;
-            System.out.println("Up Pressed");
         }
         if (keyHandler.getDownPressed() == true) {
             playerY += playerSpeed;
-            System.out.println("Down Pressed");
         }
         if (keyHandler.getLeftPressed() == true) {
             playerX -= playerSpeed;
-            System.out.println("Left Pressed");
         }
         if (keyHandler.getRightPressed() == true) {
             playerX += playerSpeed;
-            System.out.println("Right Pressed");
         }
     }
 


### PR DESCRIPTION
# 実装されたGameWindowクラス内で`Override`されたframeメソッド内
# キー操作 W = 上, S = 下, D = 右,  A= 左

frameメソッド内にstartThread()を呼び出していたのですが,画面に描画されているブロックはキー操作しても動きませんでした。解決した方法では,GameWindowクラスのGameWindowのコンストラクタで, this.startThread();で初期化するようにするとキー操作でW,S,D,Aでそれぞれの4方向の動きができるようになりました。

それはなぜそのようにするとキー操作が可能になったかといいますと,FrameFactoryクラスのcreateFrameメソッド内でフレームを作成した後.フレームにgameWindowのインスタンスを貼り付けているのですが,GameWindowクラス内で`Override`されたframeメソッド内にstartThread();を呼び出しても座標で決めた初期値でしか描画されず,それぞれのキー入力しても,次の描画されているブロックがフレームに張り付けられていないので,実際には動いているけど画面上では動いていないってことになるんだと思いました。

動いていない時

![スクリーンショット 2025-02-22 095814](https://github.com/user-attachments/assets/384df9df-5ab5-4316-a016-f42aa8deee7b)

動いた時




https://github.com/user-attachments/assets/7ba51ffe-6d75-4a7e-9e39-b3fa2b076de2


修正前のコード

![image](https://github.com/user-attachments/assets/76b1ae74-da96-4d1a-9f14-bfb09aa351d9)

修正後のコード


![image](https://github.com/user-attachments/assets/118d0fde-3b0c-47a2-92a5-0487ba4b2611)
